### PR TITLE
Improve repository flattening scripts

### DIFF
--- a/Flatten-GUI.ps1
+++ b/Flatten-GUI.ps1
@@ -12,15 +12,16 @@ AAABAAYAEBAAAAAAIABPAgAAZgAAACAgAAAAACAAygQAALUCAAAwMAAAAAAgAE8HAAB/BwAAQEAAAAAA
 
 function Set-FormIcon {
   param([System.Windows.Forms.Form]$Form)
+  $ms = $null
   try {
     $bytes = [Convert]::FromBase64String($IconBase64)
     $ms = New-Object System.IO.MemoryStream(,$bytes)
     $icon = New-Object System.Drawing.Icon($ms)
     $Form.Icon = $icon
-  }
-
-catch {
+  } catch {
     # ignore icon issues
+  } finally {
+    if ($ms) { $ms.Dispose() }
   }
 }
 


### PR DESCRIPTION
## Summary
- fix API summary generation
- make extension detection case-insensitive and default to ASCII tree
- dispose icon stream in GUI wrapper

## Testing
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path . -Recurse"`
- `pwsh -NoProfile -File ./Flatten-CodeRepo.ps1 -Path . -OutputFile flat.txt -MapFile map.txt -Quiet`


------
https://chatgpt.com/codex/tasks/task_e_68ad91321bc4832e89a9a33bfee2d970